### PR TITLE
build: type exports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "experimentalDecorators": false,
     "allowJs": false,
     "isolatedModules": false,
+    "removeComments": true,
 
     /* Strictness Checks */
     "alwaysStrict": true,

--- a/use-react-workers/README.md
+++ b/use-react-workers/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  use-react-workers - Reacts hooks for Web Workers
+  `use-react-workers` Reacts hooks for Web Workers
 </h1>
 
 ## 🎨 Features
@@ -169,7 +169,7 @@ The library is experimental so if you find a **bug** or would like to request a 
 
 _How to contribute?_
 
-Read [CONTRIBUTE.md](docs/CONTRIBUTE.md)
+Read [CONTRIBUTE.md](CONTRIBUTE.md)
 
 ## 📜 License
 

--- a/use-react-workers/package.json
+++ b/use-react-workers/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-react-workers",
   "description": "React Hooks for Web Workers & Web Worker utilities",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "source": "src/index.ts",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/use-react-workers/src/index.ts
+++ b/use-react-workers/src/index.ts
@@ -1,4 +1,7 @@
-export { useWorkerFunc } from './useWorkerFunc';
-export { useWorkerState } from './useWorkerState';
-export { useWorker } from './useWorker';
+// Hooks
+export * from './useWorkerFunc';
+export * from './useWorkerState';
+export * from './useWorker';
+
+// Types
 export * from './types';

--- a/use-react-workers/src/useWorker.ts
+++ b/use-react-workers/src/useWorker.ts
@@ -14,11 +14,21 @@ const defaultOptions = {
   transferable: TRANSFERABLE_TYPE.AUTO,
 };
 
+export type UseWorker = <T extends (...funcArgs: any[]) => any>(
+  func: T,
+  options?: Options
+) => {
+  postMessage: (...funcArgs: Parameters<T>) => void;
+  onMessage: (callBack: (e: MessageEvent) => void) => void;
+  terminate: () => void;
+  status: WorkerStatus;
+};
+
 /**
  * @param {Function} func the function to run with web worker
  * @param {Options} options useWorkerFunc option params
  */
-export const useWorker = <T extends (...funcArgs: any[]) => any>(
+export const useWorker: UseWorker = <T extends (...funcArgs: any[]) => any>(
   func: T,
   options: Options = defaultOptions
 ): typeof workerHook => {

--- a/use-react-workers/src/useWorkerFunc.ts
+++ b/use-react-workers/src/useWorkerFunc.ts
@@ -17,7 +17,7 @@ export interface Controller {
   terminate: () => void;
 }
 
-interface Promise {
+interface PromiseResponse {
   resolve: (result: any | ErrorEvent) => void;
   reject: (result: any) => void;
 }
@@ -29,16 +29,23 @@ const defaultOptions = {
   transferable: TRANSFERABLE_TYPE.AUTO,
 };
 
-const defaultPromise: Promise = {
+const defaultPromise: PromiseResponse = {
   resolve: () => null,
   reject: () => null,
 };
+
+export type UseWorkerFunc = <T extends (...funcArgs: any[]) => any>(
+  func: T,
+  options?: Options
+) => [(...funcArgs: Parameters<T>) => Promise<ReturnType<T>>, Controller];
 
 /**
  * @param {Function} func the function to run with web worker
  * @param {Options} options useWorkerFunc option params
  */
-export const useWorkerFunc = <T extends (...funcArgs: any[]) => any>(
+export const useWorkerFunc: UseWorkerFunc = <
+  T extends (...funcArgs: any[]) => any
+>(
   func: T,
   options: Options = defaultOptions
 ): [typeof workerHook, Controller] => {
@@ -51,7 +58,7 @@ export const useWorkerFunc = <T extends (...funcArgs: any[]) => any>(
     WorkerStatus.IDLE
   );
   const worker = useRef<Worker & { _url?: string }>();
-  const promise = useRef<Promise>(defaultPromise);
+  const promise = useRef<PromiseResponse>(defaultPromise);
   const timeoutId = useRef<NodeJS.Timeout>();
 
   const killWorker = useCallback(() => {

--- a/use-react-workers/src/useWorkerState.ts
+++ b/use-react-workers/src/useWorkerState.ts
@@ -1,13 +1,25 @@
 import { useEffect, useState } from 'react';
 import { Controller, useWorkerFunc } from './useWorkerFunc';
 
+export type UseWorkerState = <
+  R extends ReturnType<T>,
+  T extends (args: any) => any = (args: any) => any
+>(
+  func: T,
+  defaultState: R
+) => [
+  ReturnType<T> | null,
+  (...args: Parameters<T>) => Promise<void>,
+  Controller
+];
+
 /**
  * Executes a function in [useWorkerFunc](./useWorkerFunc) and retrieves its result in React state.
  * @param {T} func - The function to be executed in the web worker.
  * @param {ReturnType<T>} defaultState - The arguments to be passed to the function.
  * @returns {[ReturnType<T> | null, (input: Parameters<T>) => Promise<void>,  Controller]} - An array containing the result of the function and a controller object.
  */
-export const useWorkerState = <
+export const useWorkerState: UseWorkerState = <
   R extends ReturnType<T>,
   T extends (args: any) => any = (args: any) => any
 >(

--- a/use-react-workers/vite.config.js
+++ b/use-react-workers/vite.config.js
@@ -28,7 +28,6 @@ export default defineConfig(async () => ({
   plugins: [
     react(),
     dts({
-      rollupTypes: true,
       outDir: OUT_DIR,
     }),
   ],


### PR DESCRIPTION
Instead of relying on type declarations from `dts` this exports function types with each function. 

The type declarations are also removed from the rollup (single entry) style so they can be imported on a per function base if desired. This should resolve #5 and pass the [arethetypeswrong](https://arethetypeswrong.github.io/) resolution error. 
 